### PR TITLE
fixes

### DIFF
--- a/src/supabase/models.ts
+++ b/src/supabase/models.ts
@@ -140,8 +140,7 @@ export type Database = {
                     id: number
                     image: string
                     location: string
-                    reasonForDeactivation: string | null
-                    reasonForReactivation: string | null
+                    reason: string | null
                     status: number
                     title: string
                     userId: string
@@ -155,8 +154,7 @@ export type Database = {
                     id?: number
                     image: string
                     location: string
-                    reasonForDeactivation?: string | null
-                    reasonForReactivation?: string | null
+                    reason?: string | null
                     status?: number
                     title: string
                     userId: string
@@ -170,8 +168,7 @@ export type Database = {
                     id?: number
                     image?: string
                     location?: string
-                    reasonForDeactivation?: string | null
-                    reasonForReactivation?: string | null
+                    reason?: string | null
                     status?: number
                     title?: string
                     userId?: string

--- a/src/views/ProblemDetailView/components/ProblemDetails.tsx
+++ b/src/views/ProblemDetailView/components/ProblemDetails.tsx
@@ -83,11 +83,8 @@ const ProblemDetails = ({ problem, category, comments, goTo }: Props) => {
     )
 
     const isDisabled = useMemo(
-        () =>
-            isNil(session) ||
-            problem.status === ProblemStatus.Done ||
-            problem.status === ProblemStatus.Cancelled,
-        [problem.status, session],
+        () => problem.status === ProblemStatus.Done || problem.status === ProblemStatus.Cancelled,
+        [problem.status],
     )
 
     const {
@@ -234,7 +231,7 @@ const ProblemDetails = ({ problem, category, comments, goTo }: Props) => {
                         {problem.status === ProblemStatus.Done ? (
                             <>
                                 {getRatingIcons({
-                                    status: ProblemStatus.Done,
+                                    status: problem.status,
                                     rating: stars,
                                 })}
                                 <Text style={styles.text}>{amountOfStars}</Text>
@@ -242,7 +239,7 @@ const ProblemDetails = ({ problem, category, comments, goTo }: Props) => {
                         ) : (
                             <>
                                 {getRatingIcons({
-                                    status: ProblemStatus.Done,
+                                    status: problem.status,
                                     rating: importance,
                                 })}
                                 <Text style={styles.text}>{amountOfImportance}</Text>
@@ -257,7 +254,7 @@ const ProblemDetails = ({ problem, category, comments, goTo }: Props) => {
                     <Text style={globalStyles.subtitle}>
                         {problem.status === ProblemStatus.Done ? 'Lösung:' : 'Deaktivierungsgrund:'}
                     </Text>
-                    <Text style={styles.text}>{problem.reasonForDeactivation}</Text>
+                    <Text style={styles.text}>{problem.reason}</Text>
                 </View>
             ) : (
                 <View style={globalStyles.flexRowWithSpace}>
@@ -267,7 +264,7 @@ const ProblemDetails = ({ problem, category, comments, goTo }: Props) => {
                         onPress={() => {
                             onHelpful(userReview?.helpful ? null : true)
                         }}
-                        disabled={isDisabled}
+                        disabled={isNil(session)}
                         icon={() => (
                             <Icon
                                 source='thumb-up'
@@ -289,7 +286,7 @@ const ProblemDetails = ({ problem, category, comments, goTo }: Props) => {
                         onPress={() => {
                             onHelpful(userReview?.helpful === false ? null : false)
                         }}
-                        disabled={isDisabled}
+                        disabled={isNil(session)}
                         icon={() => (
                             <Icon
                                 source='thumb-down'

--- a/src/views/ProblemDetailView/components/ProblemReactivation.tsx
+++ b/src/views/ProblemDetailView/components/ProblemReactivation.tsx
@@ -38,7 +38,7 @@ const ProblemReactivation = ({ problem, onClose, onSubmit: onSubmitProp }: Props
             ...problem,
             latitude: undefined,
             longitude: undefined,
-            reasonForReactivation: undefined,
+            reason: undefined,
         },
     })
     const {
@@ -89,7 +89,7 @@ const ProblemReactivation = ({ problem, onClose, onSubmit: onSubmitProp }: Props
                 </View>
 
                 <TextInput
-                    name='reasonForReactivation'
+                    name='reason'
                     label='Begründung'
                     multiline={true}
                     rules={{

--- a/src/views/ProblemDetailView/components/ProblemReview.tsx
+++ b/src/views/ProblemDetailView/components/ProblemReview.tsx
@@ -36,7 +36,7 @@ const ProblemReview = ({ problem, categories, onClose, onSubmit: onSubmitProp }:
             ...problem,
             latitude: undefined,
             longitude: undefined,
-            reasonForDeactivation: null,
+            reason: null,
         },
     })
     const {
@@ -117,7 +117,7 @@ const ProblemReview = ({ problem, categories, onClose, onSubmit: onSubmitProp }:
                         />
 
                         <TextInput
-                            name='reasonForDeactivation'
+                            name='reason'
                             label='Begründung'
                             multiline={true}
                             disabled={!isDirty}


### PR DESCRIPTION
- reasonForReactivation wurde gar nicht genutzt, deswegen dachte ich mir, dass wir das direkt einfach yeeten und uns die mühe für zusätzliche logik sparen können
- isNil(session) bei isDisabled hat dafür gesorgt, dass unangemeldete User immer einen Deaktivierungsgrund ohne Inhalt bei nicht deaktivierten problemen gesehen haben
- folgender Code hat dafür gesorgt, dass nur noch Sterne angezeigt werden, egal ob das Problem gelöst wurde oder nicht:
{getRatingIcons({
    status: ProblemStatus.Done,
    rating: stars,
})}